### PR TITLE
auto-configure rubocop to allow for workspace-wide configuration

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -1,0 +1,14 @@
+root_config     = File.join(Autoproj.workspace.root_dir, '.rubocop.yml')
+autoproj_config = File.join(Autoproj.workspace.config_dir, 'rubocop.yml')
+
+unless File.exist?(autoproj_config)
+    File.open(autoproj_config, 'w') do |io|
+        YAML.dump({ 'inherit_gem' => { 'rubocop-rock' => 'defaults.yml' } }, io)
+    end
+    FileUtils.touch autoproj_config
+end
+
+File.open(root_config, 'w') do |io|
+    YAML.dump({ 'inherit_from' => [autoproj_config] }, io)
+end
+

--- a/packages.osdeps
+++ b/packages.osdeps
@@ -2,6 +2,7 @@ debase: gem
 rubocop: gem
 ruby-debug-ide: gem
 solargraph: gem
+rubocop-rock: gem
 
 rock.vscode.gems:
     osdep:
@@ -9,3 +10,4 @@ rock.vscode.gems:
     - rubocop
     - ruby-debug-ide
     - solargraph
+    - rubocop-rock


### PR DESCRIPTION
This sets up rubocop to load its configuration from autoproj/rubocop.yml,
from everywhere in the workspace. Note that packages that would define
their own rubocop file would override this.

The default `autoproj/rubocop.yml` file relies on a new rubocop-rock
gem that holds a default configuration, which matches as reasonably
as possible existing Ruby code in Rock. Note that this integration
does *not* change `autoproj/rubocop.yml` once it has been generated,
so one can remove these defaults if (s)he wishes to.

Rubocop will be configured and enabled by default by the vscode-rock gem
after version 0.5