### PR TITLE
remove definition of rubocop

### DIFF
--- a/packages.osdeps
+++ b/packages.osdeps
@@ -1,5 +1,4 @@
 debase: gem
-rubocop: gem
 ruby-debug-ide: gem
 solargraph: gem
 rubocop-rock: gem


### PR DESCRIPTION
It's now defined in rock.core