### PR TITLE
fix: force version of debase-ruby_core_source to pre-3.2.0

### DIFF
--- a/packages.osdeps
+++ b/packages.osdeps
@@ -1,4 +1,8 @@
-debase: gem
+debase:
+    gem:
+        - debase
+        - "debase-ruby_core_source<3.2.0"
+
 ruby-debug-ide: gem
 solargraph: gem
 rubocop-rock: gem


### PR DESCRIPTION
We have bundler failures (randomly, but often) on debase. Since debase has not changed, but debase-ruby_core_source just got a new release, I'm doing a shot in the dark and assume this is the cause.