### PR TITLE
fix: restrict psych to version < 5 on Ruby 2.7

### DIFF
--- a/packages.osdeps
+++ b/packages.osdeps
@@ -17,6 +17,9 @@ rock.vscode.gems:
     - solargraph
     - rubocop-rock
     - g++-multilib
+    - psych
+
+psych: ignore
 
 tcl-dev:
   debian,ubuntu: tcl-dev
@@ -26,4 +29,3 @@ liblua5.1-dev:
 
 libluabind-dev:
   debian,ubuntu: libluabind-dev
-

--- a/packages.osdeps-ruby27
+++ b/packages.osdeps-ruby27
@@ -1,0 +1,5 @@
+psych:
+    gem:
+    - name: psych
+      version: "< 5"
+


### PR DESCRIPTION
Version 5+ is source-incompatible with the built-in version of ruby 2.7, which causes problems in some conditions.